### PR TITLE
feat(transpiler): more looser loose parser

### DIFF
--- a/packages/transpiler/__tests__/loose_plugin.test.ts
+++ b/packages/transpiler/__tests__/loose_plugin.test.ts
@@ -58,19 +58,22 @@ describe("loosePlugin", () => {
     expect(testExpr.property.name).toBe(DUMMY_PLACEHOLDER);
   });
 
-  test("should fail on invalid bracket access", () => {
-    const code = "foo[var]";
-    expect(() => {
-      LooseParser.parse(code, { ecmaVersion: "latest" });
-    }).toThrow();
-  });
 
-  test("should fail on invalid optional call argument", () => {
-    const code = "foo?.(var)";
-    expect(() => {
-      LooseParser.parse(code, { ecmaVersion: "latest" });
-    }).toThrow();
-  });
+  test.each([
+    "if (",
+    "if ()",
+    "if (a)",
+    "if (a) {",
+    "if (:)",
+    "if (:) {",
+    "if () }",
+    "if (a) }",
+    "if (:) }",
+  ])("incomplete if", (code) => {
+    const ast = LooseParser.parse(code, { ecmaVersion: "latest", ranges: true });
+    expect(ast.body[0].type).toBeOneOf(["IfStatement", "ErrorStatement"]);
+    console.log(ast.body[0])
+  })
 });
 
 test("comment kept in loose parse", () => {

--- a/packages/transpiler/__tests__/loose_plugin.test.ts
+++ b/packages/transpiler/__tests__/loose_plugin.test.ts
@@ -71,9 +71,8 @@ describe("loosePlugin", () => {
     "if (:) }",
   ])("incomplete if", (code) => {
     const ast = LooseParser.parse(code, { ecmaVersion: "latest", ranges: true });
-    expect(ast.body[0].type).toBeOneOf(["IfStatement", "ErrorStatement"]);
-    console.log(ast.body[0])
-  })
+    expect(["IfStatement", "ErrorStatement"]).toContain(ast.body[0].type);
+  });
 });
 
 test("comment kept in loose parse", () => {

--- a/packages/transpiler/src/parse/index.ts
+++ b/packages/transpiler/src/parse/index.ts
@@ -59,6 +59,11 @@ export function parseLoose(
     const ast = GtsParser.parse(input, {
       ecmaVersion: "latest",
       sourceType: "module",
+      allowImportExportEverywhere: true,
+      allowReturnOutsideFunction: true,
+      allowAwaitOutsideFunction: true,
+      allowSuperOutsideMethod: true,
+      checkPrivateFields: false,
       locations: true,
       ranges: true,
       onComment,

--- a/packages/transpiler/src/parse/loose_plugin.ts
+++ b/packages/transpiler/src/parse/loose_plugin.ts
@@ -15,7 +15,7 @@ export function loosePlugin() {
           return this.createDummyIdentifier();
         }
       };
-      readonly #proxiedThis = new Proxy(this, {
+      readonly #proxiedThisTrapParseIdent = new Proxy(this, {
         get: (target, prop) => {
           if (prop === "parseIdent") {
             return this._patchedParseIdent;
@@ -48,7 +48,7 @@ export function loosePlugin() {
         forInit?: boolean | "await",
       ): AST.Expression {
         return super.parseSubscript.call(
-          this.#proxiedThis,
+          this.#proxiedThisTrapParseIdent,
           base,
           startPos,
           startLoc,
@@ -57,6 +57,80 @@ export function loosePlugin() {
           optionalChained,
           forInit,
         );
+      }
+
+      // Parsing block statements typically has:
+      // ```js
+      // while (this.type !== tokTypes.braceR) {
+      //   this.parseStatement();
+      // }
+      // ```
+      // But what happen if next token is EOF? since we tolerant error inside `parseStatement`,
+      // so it fells into infinite loop. To avoid this, we use a proxy to trap the `this.type`
+      // access and return a fake `braceR` when the current token is EOF.
+      readonly #proxiedThisTrapEofToRbrace = new Proxy(this, {
+        get: (target, prop) => {
+          if (prop === "type" && target.type === tokTypes.eof) {
+            return tokTypes.braceR;
+          }
+          const value = Reflect.get(target, prop);
+          if (typeof value === "function") {
+            return value.bind(target);
+          }
+          return value;
+        },
+      });
+
+      override parseBlock(
+        createNewLexicalScope?: boolean,
+        node?: AST.BlockStatement,
+        exitStrict?: boolean,
+      ): AST.BlockStatement {
+        return super.parseBlock.call(
+          this.#proxiedThisTrapEofToRbrace,
+          createNewLexicalScope,
+          node,
+          exitStrict,
+        );
+      }
+      override parseClassStaticBlock(node: AST.Node): AST.StaticBlock {
+        return super.parseClassStaticBlock.call(
+          this.#proxiedThisTrapEofToRbrace,
+          node,
+        );
+      }
+      override parseSwitchStatement(node: AST.Node): AST.SwitchStatement {
+        return super.parseSwitchStatement.call(
+          this.#proxiedThisTrapEofToRbrace,
+          node,
+        );
+      }
+
+      override parseStatement(
+        context?: string | null,
+        topLevel?: boolean,
+        exports?: AST.ExportSpecifier,
+      ): AST.ExpressionStatement | AST.Statement | AST.GTSDefineStatement {
+        const { start, startLoc, lastTokEnd, lastTokEndLoc } = this;
+        if (topLevel && this.eat(tokTypes.braceR)) {
+          const errorNode: any = this.startNodeAt(start, startLoc);
+          errorNode.error = "Unexpected token }";
+          return this.finishNode(errorNode, "ErrorStatement");
+        }
+        try {
+          return super.parseStatement(context, topLevel, exports);
+        } catch (e) {
+          const errorNode: any = this.startNodeAt(lastTokEnd, lastTokEndLoc);
+          errorNode.error = (e as Error)?.message;
+          while (
+            this.type !== tokTypes.eof &&
+            this.type !== tokTypes.semi &&
+            this.type !== tokTypes.braceR
+          ) {
+            this.next();
+          }
+          return this.finishNode(errorNode, "ErrorStatement");
+        }
       }
     };
   };

--- a/packages/transpiler/src/parse/loose_plugin.ts
+++ b/packages/transpiler/src/parse/loose_plugin.ts
@@ -65,8 +65,8 @@ export function loosePlugin() {
       //   this.parseStatement();
       // }
       // ```
-      // But what happen if next token is EOF? since we tolerant error inside `parseStatement`,
-      // so it fells into infinite loop. To avoid this, we use a proxy to trap the `this.type`
+      // But what happens if the next token is EOF? Since we tolerate errors inside `parseStatement`,
+      // it can fall into an infinite loop. To avoid this, we use a proxy to trap `this.type`
       // access and return a fake `braceR` when the current token is EOF.
       readonly #proxiedThisTrapEofToRbrace = new Proxy(this, {
         get: (target, prop) => {

--- a/packages/transpiler/src/transform/volar/printer.ts
+++ b/packages/transpiler/src/transform/volar/printer.ts
@@ -240,18 +240,18 @@ export function getPrintOptions(
       ErrorStatement(node: any, context: PrinterContext<CodeInformation>) {
         if (node.range) {
           context.writePreservedNode(node);
-          context.createExtraMapping(
-            {
-              start: node.range[1],
-              end: node.range[1] + 1,
-            },
-            context.generatedOffset,
-            context.generatedOffset + 1,
-            VERIFICATION_ONLY_MAPPING_DATA,
-          );
+          const sourceEnd = Math.min(node.range[1] + 1, context.source.length);
+          if (sourceEnd > node.range[1]) {
+            context.createExtraMapping(
+              { start: node.range[1], end: sourceEnd },
+              context.generatedOffset,
+              context.generatedOffset + 1,
+              VERIFICATION_ONLY_MAPPING_DATA,
+            );
+          }
         } else {
           // Emit a TS error indicate the error. This should not happen.
-          context.write(`((_: unknown) => 0)(${JSON.stringify(node.error ?? "Unknown error")});`);
+          context.write(`((_: never) => 0)(${JSON.stringify(node.error ?? "Unknown error")});`);
         }
       },
     },

--- a/packages/transpiler/src/transform/volar/printer.ts
+++ b/packages/transpiler/src/transform/volar/printer.ts
@@ -127,8 +127,9 @@ export function getPrintOptions(
             context.writeMapped(text, identifier.range[0], rangeEnd);
           } else {
             // b) otherwise create extra mapping directly for next character
+            const rangeEnd = Math.min(node.range[0] + 1, context.source.length);
             context.createExtraMapping(
-              { start: identifier.range[0], end: identifier.range[0] + 1 },
+              { start: identifier.range[0], end: rangeEnd },
               context.generatedOffset,
               context.generatedOffset + 1,
               DEFAULT_VOLAR_MAPPING_DATA,
@@ -240,18 +241,18 @@ export function getPrintOptions(
       ErrorStatement(node: any, context: PrinterContext<CodeInformation>) {
         if (node.range) {
           context.writePreservedNode(node);
-          const sourceEnd = Math.min(node.range[1] + 1, context.source.length);
-          if (sourceEnd > node.range[1]) {
-            context.createExtraMapping(
-              { start: node.range[1], end: sourceEnd },
-              context.generatedOffset,
-              context.generatedOffset + 1,
-              VERIFICATION_ONLY_MAPPING_DATA,
-            );
-          }
+          const rangeEnd = Math.min(node.range[1] + 1, context.source.length);
+          context.createExtraMapping(
+            { start: node.range[1], end: rangeEnd },
+            context.generatedOffset,
+            context.generatedOffset + 1,
+            VERIFICATION_ONLY_MAPPING_DATA,
+          );
         } else {
           // Emit a TS error indicate the error. This should not happen.
-          context.write(`((_: never) => 0)(${JSON.stringify(node.error ?? "Unknown error")});`);
+          context.write(
+            `((_: never) => 0)(${JSON.stringify(node.error ?? "Unknown error")});`,
+          );
         }
       },
     },

--- a/packages/transpiler/src/transform/volar/printer.ts
+++ b/packages/transpiler/src/transform/volar/printer.ts
@@ -35,12 +35,15 @@ export function getPrintOptions(
       if (node.type === "Identifier" && (node as Identifier).isDummy) {
         return false;
       }
+      if ((node.type as string) === "ErrorStatement") {
+        return false;
+      }
       if (state.attributeNameNodes.has(node as Identifier | Literal)) {
         return false;
       }
       return state.sourceNodes.has(node as Node);
     },
-    
+
     printCommentsOnUntouchedNodes: true,
     getLeadingComments: (node) => (node as Node).leadingComments,
     getTrailingComments: (node) => (node as Node).trailingComments,
@@ -111,15 +114,27 @@ export function getPrintOptions(
         const identifier = node as Identifier;
         if (identifier.isDummy && identifier.range) {
           const text = state.lastArgNodes.has(identifier) ? "," : "";
-          // extend the source mapping of dummy id to the before next token
+          // extend the source mapping of dummy id.
           let firstNonWhiteSpaceIndex = context.source
             .slice(identifier.range[1])
             .search(/\S/);
-          const rangeEnd =
-            firstNonWhiteSpaceIndex === -1
-              ? context.source.length
-              : identifier.range[1] + firstNonWhiteSpaceIndex;
-          context.writeMapped(text, identifier.range[0], rangeEnd);
+          if (firstNonWhiteSpaceIndex !== 0) {
+            // a) if next char-seq is whitespaces, write them as mapped
+            const rangeEnd =
+              firstNonWhiteSpaceIndex === -1
+                ? context.source.length
+                : identifier.range[1] + firstNonWhiteSpaceIndex;
+            context.writeMapped(text, identifier.range[0], rangeEnd);
+          } else {
+            // b) otherwise create extra mapping directly for next character
+            context.createExtraMapping(
+              { start: identifier.range[0], end: identifier.range[0] + 1 },
+              context.generatedOffset,
+              context.generatedOffset + 1,
+              DEFAULT_VOLAR_MAPPING_DATA,
+            );
+            context.write(text);
+          }
         } else if (
           identifier.range &&
           state.attributeNameNodes.has(identifier)
@@ -221,6 +236,23 @@ export function getPrintOptions(
         context.write(".");
         context.writeSource(node.whiteSpaceStart, node.whiteSpaceEnd);
         context.write(";");
+      },
+      ErrorStatement(node: any, context: PrinterContext<CodeInformation>) {
+        if (node.range) {
+          context.writePreservedNode(node);
+          context.createExtraMapping(
+            {
+              start: node.range[1],
+              end: node.range[1] + 1,
+            },
+            context.generatedOffset,
+            context.generatedOffset + 1,
+            VERIFICATION_ONLY_MAPPING_DATA,
+          );
+        } else {
+          // Emit a TS error indicate the error. This should not happen.
+          context.write(`((_: unknown) => 0)(${JSON.stringify(node.error ?? "Unknown error")});`);
+        }
       },
     },
     // Enable triggering signature completion


### PR DESCRIPTION
This PR aimed to fix this issue: when user is pressing:

```
{
    if (cond) // <- cursor here
}
```
since this is not a valid `IfStatement`, so parser returns early error, and the transpiled TS file did not even arrived to TSServer, and user hints around `cond` just disappeared. This is really disappointing.

The PR fix this by allow `parseStatement` of acorn throw and recover by:
- Record the range of each statement and,
- If it throws, catch the error and try recover the parser by continue eating tokens until `}`, `;` or EOF
- And add a `ErrorStatement` "fake" node into AST, which will handled by our TS printer.

On printer side, we have specially handling for `ErrorStatement` that includes 1 more character as verification-only mappings, so that TSServer's `required [production]` error squiggle can be mapped back.
